### PR TITLE
Inclusão da funcionalidade de Edição. 

### DIFF
--- a/CROW/src/main/java/br/edu/garanhuns/ifpe/crow/tags/BasicCrudEdit.java
+++ b/CROW/src/main/java/br/edu/garanhuns/ifpe/crow/tags/BasicCrudEdit.java
@@ -1,0 +1,119 @@
+package br.edu.garanhuns.ifpe.crow.tags;
+
+
+import br.edu.garanhuns.ifpe.crow.classes.StringUtil;
+import br.edu.garanhuns.ifpe.crow.interfaces.CrowActionController;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.servlet.jsp.JspWriter;
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.tagext.SimpleTagSupport;
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+/**
+ * 
+ * @author 1860915 and Adriano
+ */
+public class BasicCrudEdit extends SimpleTagSupport{
+    
+    private String usedBean;
+    private CrowActionController usedActionController;
+    private Object beanInstance;
+    
+    public void setUsedBean(String usedBean) {
+        this.usedBean = usedBean;
+    }
+    
+    public void setBeanInstance(Object beanInstance) {
+        this.beanInstance = beanInstance;
+    }
+
+    public void setUsedController(CrowActionController usedActionController) {
+        this.usedActionController = usedActionController;
+    }
+    
+    
+    @Override
+    public void doTag() throws IOException{
+        Class classBean = null;
+        Class classController = null;
+        try {
+            classBean = Class.forName(usedBean);
+            classController = usedActionController.getClass();
+            
+            
+        } catch (ClassNotFoundException ex) {
+            getJspContext().getOut().write("<h1>Erro the class "+ex.getMessage()+" was not found</h1>");
+        }
+        
+        getJspContext().setAttribute("usedBean", classBean, PageContext.SESSION_SCOPE);
+        getJspContext().setAttribute("usedController", classController, PageContext.SESSION_SCOPE);
+        
+        JspWriter out = getJspContext().getOut();
+
+        out.println("<script src='http://code.jquery.com/jquery-3.1.1.js'></script>"
+                + "<script>$(function(){\n"
+                + "    \n"
+                + "    $(\"[value='cadastrar']\").click(function(){\n"
+                + "       var fields = $(\"[name]\");\n"
+                + "    \n"
+                + "        var parametros = \"\";\n"
+                + "    \n"
+                + "        for(var i = 0;i<fields.length;i++){\n"
+                + "            parametros += $(fields[i]).attr(\"name\")+\":\"+$(fields[i]).val()+\";\"; \n"
+                + "        }\n"
+                + "         console.log(parametros)"
+                + "    \n"
+                + "        $.post(\"GenericEditServlet\",{param:parametros},\n"
+                + "        function(data){\n"
+                + "            $(\"#mensagem\").html(data);\n"
+                + "        }); \n"
+                + "        });\n"
+                + "    \n"
+                + "    \n"
+                + "    \n"
+                + "});</script>");
+
+        out.println("<p id='mensagem'></p>");
+        out.println("<form>");
+        Field[] fields = classBean.getDeclaredFields();
+        Class[] paramsClassesEmpty = new Class[0];
+        Object[] paramsNull = new Object[0];
+        
+        
+        for (Field f : fields) {
+            try {
+                out.print(f.getName()
+                        + ": <input type='text' name='"
+                        + f.getName()
+                        + "' value='"
+                        + beanInstance.getClass().getMethod("get"+StringUtil.upperCaseFirst(f.getName()), paramsClassesEmpty)
+                                .invoke(beanInstance, paramsNull)
+                        +"'/><br/>");
+            } catch (NoSuchMethodException ex) {
+                Logger.getLogger(BasicCrudEdit.class.getName()).log(Level.SEVERE, null, ex);
+            } catch (SecurityException ex) {
+                Logger.getLogger(BasicCrudEdit.class.getName()).log(Level.SEVERE, null, ex);
+            } catch (IllegalAccessException ex) {
+                Logger.getLogger(BasicCrudEdit.class.getName()).log(Level.SEVERE, null, ex);
+            } catch (IllegalArgumentException ex) {
+                Logger.getLogger(BasicCrudEdit.class.getName()).log(Level.SEVERE, null, ex);
+            } catch (InvocationTargetException ex) {
+                Logger.getLogger(BasicCrudEdit.class.getName()).log(Level.SEVERE, null, ex);
+            }
+        }
+        out.print("<input type='button' value='cadastrar' />");
+        out.println("</form>");
+    }
+    
+    
+}

--- a/CROW/src/main/java/br/edu/garanhuns/ifpe/crow/view/servlets/GenericEditServlet.java
+++ b/CROW/src/main/java/br/edu/garanhuns/ifpe/crow/view/servlets/GenericEditServlet.java
@@ -23,8 +23,8 @@ import javax.servlet.http.HttpSession;
  * @author 1860915
  */
 
-@WebServlet(name = "GenericInsertServlet", urlPatterns = {"/GenericInsertServlet"})
-public class GenericInsertServlet extends HttpServlet {
+@WebServlet(name = "GenericEditServlet", urlPatterns = {"/GenericEditServlet"})
+public class GenericEditServlet extends HttpServlet {
 
     /**
      * Processes requests for both HTTP <code>GET</code> and <code>POST</code>
@@ -78,11 +78,11 @@ public class GenericInsertServlet extends HttpServlet {
                             try {
                                 m.invoke(objectBean, p.split(":")[1]);
                             } catch (IllegalAccessException ex) {
-                                Logger.getLogger(GenericInsertServlet.class.getName()).log(Level.SEVERE, null, ex);
+                                Logger.getLogger(GenericEditServlet.class.getName()).log(Level.SEVERE, null, ex);
                             } catch (IllegalArgumentException ex) {
-                                Logger.getLogger(GenericInsertServlet.class.getName()).log(Level.SEVERE, null, ex);
+                                Logger.getLogger(GenericEditServlet.class.getName()).log(Level.SEVERE, null, ex);
                             } catch (InvocationTargetException ex) {
-                                Logger.getLogger(GenericInsertServlet.class.getName()).log(Level.SEVERE, null, ex);
+                                Logger.getLogger(GenericEditServlet.class.getName()).log(Level.SEVERE, null, ex);
                             }
                         }
                     }
@@ -93,7 +93,7 @@ public class GenericInsertServlet extends HttpServlet {
         
         Method controllerMethod;
         try {
-            controllerMethod = objectController.getClass().getDeclaredMethod("create",Object.class);
+            controllerMethod = objectController.getClass().getDeclaredMethod("update",Object.class);
             
             controllerMethod.invoke(objectController, objectBean);
         } catch (NoSuchMethodException ex) {

--- a/CROW/src/main/resources/META-INF/tlds/crow.tld
+++ b/CROW/src/main/resources/META-INF/tlds/crow.tld
@@ -20,4 +20,27 @@
           <rtexprvalue>true</rtexprvalue>
       </attribute>
   </tag>
+  <tag>
+      <name>crud_edit</name>
+      <tag-class>br.edu.garanhuns.ifpe.crow.tags.BasicCrudEdit</tag-class>
+      <body-content>empty</body-content>
+      
+      <attribute>
+          <name>usedBean</name>
+          <required>true</required>
+          <rtexprvalue>true</rtexprvalue>
+      </attribute>
+      
+      <attribute>
+          <name>beanInstance</name>
+          <required>true</required>
+          <rtexprvalue>true</rtexprvalue>
+      </attribute>
+      
+      <attribute>
+          <name>usedController</name>
+          <required>true</required>
+          <rtexprvalue>true</rtexprvalue>
+      </attribute>
+  </tag>
 </taglib>


### PR DESCRIPTION
Inclusão da funcionalidade de Edição. Tag crud_edit recebe um Bean do tipo a ser editado e salva as alterações. Foi replicado o mesmo codigo da função Cadastrar. NO momento só são aceitos tipos int e string.
Alterei o tipo de parametro da chamada de create no servlet de cadastro para Object, necessário para evitar uso de cast na função create da interface de CrowActionControler. Alteração sem perca das funcionalidades.
